### PR TITLE
Added simple path resolving for the rest of the WSL filesystem.…

### DIFF
--- a/caller/wrun.c
+++ b/caller/wrun.c
@@ -873,14 +873,39 @@ int main(int argc, char *argv[])
         shift(&argc, &argv);
         string_append(&outbash_command, "~");
     } else {
-        char* cwd = agetcwd();
+		char* cwd = agetcwd();
         if (!((strncmp(cwd, MNT_DRIVE_FS_PREFIX, strlen(MNT_DRIVE_FS_PREFIX)) == 0)
               && cwd[strlen(MNT_DRIVE_FS_PREFIX)] >= 'a'
               && cwd[strlen(MNT_DRIVE_FS_PREFIX)] <= 'z'
               && (cwd[strlen(MNT_DRIVE_FS_PREFIX) + 1] == '/'
                   || cwd[strlen(MNT_DRIVE_FS_PREFIX) + 1] == '\0'))) {
-            dprintf(STDERR_FILENO, "%s: can't translate a WSL VolFs path to a Win32 one\n", tool_name);
-            terminate = true;
+
+			char* wsl_root = getenv("WSL_PATH");
+			char* cwd_win32;
+			int i = strlen(wsl_root);
+			int cwd_len;
+
+			if (!((strncmp(cwd, "/home", 5) == 0)
+				||(strncmp(cwd, "/root", 5) == 0)
+				||(strncmp(cwd, "/data", 5) == 0))) {
+				i += strlen("\\rootfs");
+				cwd_len = i + strlen(cwd);
+				cwd_win32 = xmalloc(cwd_len + 1);
+				strcpy(cwd_win32, wsl_root);
+				strcat(cwd_win32, "\\rootfs");
+			} else {
+				cwd_len = i + strlen(cwd);
+				cwd_win32 = xmalloc(cwd_len + 1);
+				strcpy(cwd_win32, wsl_root);
+			}
+
+			strcat(cwd_win32, cwd);
+			for (; i < cwd_len; i++)
+				if (cwd_win32[i] == '/')
+					cwd_win32[i] = '\\';
+
+			string_append(&outbash_command, cwd_win32);
+			free(cwd_win32);
         } else {
             char* cwd_win32 = convert_drive_fs_path_to_win32(cwd);
             string_append(&outbash_command, cwd_win32);
@@ -972,11 +997,54 @@ int main(int argc, char *argv[])
         break;
     }
 
-    bool sep = false;
-    for (int i = 0; i < argc; i++) {
-        if (sep) string_append(&outbash_command, " ");
-        string_append(&outbash_command, argv[i]);
-        sep = true;
+	char* cwd = "";
+	if (argc > 0) {
+		cwd = argv[0];
+		if (cwd[0] == '/') {
+			if (!((strncmp(cwd, MNT_DRIVE_FS_PREFIX, strlen(MNT_DRIVE_FS_PREFIX)) == 0)
+				  && cwd[strlen(MNT_DRIVE_FS_PREFIX)] >= 'a'
+				  && cwd[strlen(MNT_DRIVE_FS_PREFIX)] <= 'z'
+				  && (cwd[strlen(MNT_DRIVE_FS_PREFIX) + 1] == '/'
+					  || cwd[strlen(MNT_DRIVE_FS_PREFIX) + 1] == '\0'))) {
+
+				char* wsl_root = getenv("WSL_PATH");
+				char* cwd_win32;
+				int i = strlen(wsl_root);
+				int cwd_len;
+
+				if (!((strncmp(cwd, "/home", 5) == 0)
+					  || (strncmp(cwd, "/root", 5) == 0)
+					  || (strncmp(cwd, "/data", 5) == 0))) {
+					i += strlen("\\rootfs");
+					cwd_len = i + strlen(cwd);
+					cwd_win32 = xmalloc(cwd_len + 1);
+					strcpy(cwd_win32, wsl_root);
+					strcat(cwd_win32, "\\rootfs");
+				} else {
+					cwd_len = i + strlen(cwd);
+					cwd_win32 = xmalloc(cwd_len + 1);
+					strcpy(cwd_win32, wsl_root);
+				}
+
+				strcat(cwd_win32, cwd);
+				for (; i < cwd_len; i++)
+					if (cwd_win32[i] == '/')
+						cwd_win32[i] = '\\';
+				string_append(&outbash_command, cwd_win32);
+				free(cwd_win32);
+			} else {
+				char* cwd_win32 = convert_drive_fs_path_to_win32(cwd);
+				string_append(&outbash_command, cwd_win32);
+				free(cwd_win32);
+			}
+		} else {
+			string_append(&outbash_command, argv[0]);
+		}
+	}
+
+    for (int i = 1; i < argc; i++) {
+		string_append(&outbash_command, argv[i]);
+        string_append(&outbash_command, " ");
     }
     string_append(&outbash_command, "\n\n");
     //dprintf(STDOUT_FILENO, "%s", outbash_command.str);

--- a/outbash/outbash.cpp
+++ b/outbash/outbash.cpp
@@ -78,6 +78,20 @@ static bool startswith(const std::basic_string<CharT>& s, const std::basic_strin
     return !s.compare(0, start.size(), start);
 }
 
+static std::wstring get_localappdata() {
+	wchar_t buf[MAX_PATH + 6];
+	UINT res = ::GetEnvironmentVariableW(L"LOCALAPPDATA", buf, MAX_PATH + 6);
+	if (res == 0 && ::GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
+		std::fprintf(stderr, "outbash: warning: LOCALAPPDATA environment variable not found\n");
+		return L"";
+	} else {
+		if (res == 0 || res > MAX_PATH) { std::fprintf(stderr, "outbash: GetEnvironmentVariable LOCALAPPDATA error\n"); std::abort(); }
+		wcscat(buf, L"\\lxss");
+		return buf;
+	}
+}
+static const std::wstring wsl_root_path = get_localappdata();
+
 class CCmdLine
 {
 public:
@@ -134,7 +148,7 @@ public:
              * outbash ~ params => bash.exe ~ - c "OUTBASH=4242 bash <escaped(params)>"
              */
 
-            cmd_line += L"OUTBASH_PORT=" + std::to_wstring(port) + L" bash " + m_escaped_bash_cmd_line_params;
+            cmd_line += L"OUTBASH_PORT=" + std::to_wstring(port) + L" WSL_PATH='" + wsl_root_path + L"' bash " + m_escaped_bash_cmd_line_params;
 
         } else {
 
@@ -332,6 +346,17 @@ static int start_command(std::wstring cmdline,
         ahl = redirs->attribute_handle_list();
         si.lpAttributeList = ahl.get_attribute_list_ptr();
     }
+	//
+	//std::wstring cmd = cmdline;
+	//if (wdir != nullptr) {
+	//	cmd = L"\"";
+	//	cmd += wdir;
+	//	cmd += L"\\";
+	//	cmd += cmdline.c_str();
+	//	cmd += L"\"";
+	//}
+	
+	SetCurrentDirectoryW(wdir);
     if (!::CreateProcessW(module, &cmdline[0], NULL, NULL, inherit_handles,
                           CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT | creation_flags,
                           (LPVOID)env, wdir, (STARTUPINFOW*)&si, &out_pi)) {


### PR DESCRIPTION
… Relative paths only work to some extent due to how folders are organized differently in the windows filesystem and the linux filesystem. A more robust implementation is required for supporting all relative path-jumping fully. (Have a look at %localappdata%\lxss and the /root, /home, /data and /rootfs directories to get a gist of it...) May result in undefined behaviour if the lxss directory isn't stored and organized where it is by default. The change on line 359 of outbash/outbash.cpp (setting the current directory) also solves an issue some programs have when not specifying the full path to the executable.
