### PR TITLE
Added path resolution to support unsafe access to bash filesystem.

### DIFF
--- a/caller/wrun.c
+++ b/caller/wrun.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include <stdbool.h>
 #include <string.h>
 #include <limits.h>
@@ -1008,7 +1009,18 @@ int main(int argc, char *argv[])
 
 	for (int i = 0; i < argc; i++) {
 		char buf[PATH_MAX + 1];
-		char* cwd = realpath(argv[i], buf);
+		char* cwd = argv[i];
+
+		//Trimming spaces for cases where extra spaces ruin the realpath
+		while (isspace(*cwd)) cwd++;
+		if (*cwd == 0)
+			continue;
+		char* end = cwd + strlen(cwd) - 1;
+		while (end > cwd && isspace(*end)) end--;
+
+		// Write new null terminator
+		*(end + 1) = 0;
+		cwd = realpath(cwd, buf);
 		if (cwd == NULL) cwd = argv[i];
 		if (cwd[0] == '/') {
 			if (!((strncmp(cwd, MNT_DRIVE_FS_PREFIX, strlen(MNT_DRIVE_FS_PREFIX)) == 0)

--- a/caller/wrun.c
+++ b/caller/wrun.c
@@ -883,9 +883,38 @@ int main(int argc, char *argv[])
         string_append(&outbash_command, "~");
     } else {
         char* cwd = agetcwd();
-        if (!is_absolute_drive_fs_path(cwd)) {
-            dprintf(STDERR_FILENO, "%s: current directory must be in DriveFs\n", tool_name);
-            terminate = true;
+		if (!((strncmp(cwd, MNT_DRIVE_FS_PREFIX, strlen(MNT_DRIVE_FS_PREFIX)) == 0)
+			  && cwd[strlen(MNT_DRIVE_FS_PREFIX)] >= 'a'
+			  && cwd[strlen(MNT_DRIVE_FS_PREFIX)] <= 'z'
+			  && (cwd[strlen(MNT_DRIVE_FS_PREFIX) + 1] == '/'
+				  || cwd[strlen(MNT_DRIVE_FS_PREFIX) + 1] == '\0'))) {
+
+			char* wsl_root = getenv("WSL_PATH");
+			char* cwd_win32;
+			int i = strlen(wsl_root);
+			int cwd_len;
+
+			if (!((strncmp(cwd, "/home", 5) == 0)
+				  || (strncmp(cwd, "/root", 5) == 0)
+				  || (strncmp(cwd, "/data", 5) == 0))) {
+				i += strlen("\\rootfs");
+				cwd_len = i + strlen(cwd);
+				cwd_win32 = xmalloc(cwd_len + 1);
+				strcpy(cwd_win32, wsl_root);
+				strcat(cwd_win32, "\\rootfs");
+			} else {
+				cwd_len = i + strlen(cwd);
+				cwd_win32 = xmalloc(cwd_len + 1);
+				strcpy(cwd_win32, wsl_root);
+			}
+
+			strcat(cwd_win32, cwd);
+			for (; i < cwd_len; i++)
+				if (cwd_win32[i] == '/')
+					cwd_win32[i] = '\\';
+
+			string_append(&outbash_command, cwd_win32);
+			free(cwd_win32);
         } else {
             char* cwd_win32 = convert_drive_fs_path_to_win32(cwd);
             string_append(&outbash_command, cwd_win32);
@@ -977,12 +1006,54 @@ int main(int argc, char *argv[])
         break;
     }
 
-    bool sep = false;
-    for (int i = 0; i < argc; i++) {
-        if (sep) string_append(&outbash_command, " ");
-        string_append(&outbash_command, argv[i]);
-        sep = true;
-    }
+	for (int i = 0; i < argc; i++) {
+		char buf[PATH_MAX + 1];
+		char* cwd = realpath(argv[i], buf);
+		if (cwd == NULL) cwd = argv[i];
+		if (cwd[0] == '/') {
+			if (!((strncmp(cwd, MNT_DRIVE_FS_PREFIX, strlen(MNT_DRIVE_FS_PREFIX)) == 0)
+				  && cwd[strlen(MNT_DRIVE_FS_PREFIX)] >= 'a'
+				  && cwd[strlen(MNT_DRIVE_FS_PREFIX)] <= 'z'
+				  && (cwd[strlen(MNT_DRIVE_FS_PREFIX) + 1] == '/'
+					  || cwd[strlen(MNT_DRIVE_FS_PREFIX) + 1] == '\0'))) {
+
+				char* wsl_root = getenv("WSL_PATH");
+				char* cwd_win32;
+				int i = strlen(wsl_root);
+				int cwd_len;
+
+				if (!((strncmp(cwd, "/home", 5) == 0)
+					  || (strncmp(cwd, "/root", 5) == 0)
+					  || (strncmp(cwd, "/data", 5) == 0))) {
+					i += strlen("\\rootfs");
+					cwd_len = i + strlen(cwd);
+					cwd_win32 = xmalloc(cwd_len + 1);
+					strcpy(cwd_win32, wsl_root);
+					strcat(cwd_win32, "\\rootfs");
+				} else {
+					cwd_len = i + strlen(cwd);
+					cwd_win32 = xmalloc(cwd_len + 1);
+					strcpy(cwd_win32, wsl_root);
+				}
+
+				strcat(cwd_win32, cwd);
+				for (; i < cwd_len; i++)
+					if (cwd_win32[i] == '/')
+						cwd_win32[i] = '\\';
+				string_append(&outbash_command, cwd_win32);
+				free(cwd_win32);
+			} else {
+				char* cwd_win32 = convert_drive_fs_path_to_win32(cwd);
+				string_append(&outbash_command, cwd_win32);
+				free(cwd_win32);
+			}
+		} else
+			string_append(&outbash_command, cwd);
+
+		if (i < argc - 1)
+			string_append(&outbash_command, " ");
+	}
+
     string_append(&outbash_command, "\n\n");
     //dprintf(STDOUT_FILENO, "%s", outbash_command.str);
     //return EXIT_FAILURE;

--- a/outbash/outbash.cpp
+++ b/outbash/outbash.cpp
@@ -78,6 +78,20 @@ static bool startswith(const std::basic_string<CharT>& s, const std::basic_strin
     return !s.compare(0, start.size(), start);
 }
 
+static std::wstring get_localappdata() {
+	wchar_t buf[MAX_PATH + 6];
+	UINT res = ::GetEnvironmentVariableW(L"LOCALAPPDATA", buf, MAX_PATH + 6);
+	if (res == 0 && ::GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
+		std::fprintf(stderr, "outbash: warning: LOCALAPPDATA environment variable not found\n");
+		return L"";
+	} else {
+		if (res == 0 || res > MAX_PATH) { std::fprintf(stderr, "outbash: GetEnvironmentVariable LOCALAPPDATA error\n"); std::abort(); }
+		wcscat(buf, L"\\lxss");
+		return buf;
+	}
+}
+static const std::wstring wsl_root_path = get_localappdata();
+
 class CCmdLine
 {
 public:
@@ -134,7 +148,7 @@ public:
              * outbash ~ params => bash.exe ~ - c "OUTBASH=4242 bash <escaped(params)>"
              */
 
-            cmd_line += L"OUTBASH_PORT=" + std::to_wstring(port) + L" bash " + m_escaped_bash_cmd_line_params;
+			cmd_line += L"OUTBASH_PORT=" + std::to_wstring(port) + L" WSL_PATH='" + wsl_root_path + L"' bash " + m_escaped_bash_cmd_line_params;
 
         } else {
 


### PR DESCRIPTION
More detailed explanation:
- Added the environment variable: WSL_PATH to bash. This is declared when outbash launches bash. It contains the location of the bash environment, which is %LOCALAPPDATA%\lxss. If your bash environment is located elsewhere, the code will have to be changed and recompiled. A compile-time variable might be added in the future.
- The run commands now check if any argument is a path and replaces it with the absolute path if that's the case.
- This does not replace relative or absolute paths for any argument consisting of more than just a path.
